### PR TITLE
Add ASP.NET Core IDMission demo

### DIFF
--- a/IDMissionPOC.sln
+++ b/IDMissionPOC.sln
@@ -1,0 +1,19 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.0.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IDMissionDemo", "src/IDMissionDemo/IDMissionDemo.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-"# IDMissionPOC" 
+# IDMissionPOC
+
+This repository contains a demo ASP.NET Core Web API project that shows how IDMission KYC verification can be integrated.
+
+The sample project lives under `src/IDMissionDemo`. It was created manually in this environment without using the `dotnet` CLI. To run it you must have the .NET 6 SDK installed locally.
+
+```
+cd src/IDMissionDemo
+ dotnet run
+```
+
+You can then send a POST request to `https://localhost:5001/api/kyc` with JSON data:
+
+```json
+{
+  "imageBase64": "<base64-encoded-image>"
+}
+```
+
+Configuration for the IDMission endpoint and credentials is located in `appsettings.json`.

--- a/src/IDMissionDemo/Controllers/KycController.cs
+++ b/src/IDMissionDemo/Controllers/KycController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/[controller]")]
+public class KycController : ControllerBase
+{
+    private readonly IDMissionClient _client;
+
+    public KycController(IDMissionClient client)
+    {
+        _client = client;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Verify([FromBody] KycRequest request)
+    {
+        if (string.IsNullOrEmpty(request.ImageBase64))
+        {
+            return BadRequest("Image is required");
+        }
+
+        var result = await _client.VerifyKycAsync(request.ImageBase64);
+        return Ok(result);
+    }
+}
+
+public class KycRequest
+{
+    public string ImageBase64 { get; set; } = string.Empty;
+}

--- a/src/IDMissionDemo/IDMissionDemo.csproj
+++ b/src/IDMissionDemo/IDMissionDemo.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/src/IDMissionDemo/Program.cs
+++ b/src/IDMissionDemo/Program.cs
@@ -1,0 +1,24 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddHttpClient();
+builder.Services.AddScoped<IDMissionClient>();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.UseAuthorization();
+app.MapControllers();
+
+app.Run();
+
+public partial class Program { }

--- a/src/IDMissionDemo/Services/IDMissionClient.cs
+++ b/src/IDMissionDemo/Services/IDMissionClient.cs
@@ -1,0 +1,37 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+public class IDMissionClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<IDMissionClient> _logger;
+    private readonly IConfiguration _configuration;
+
+    public IDMissionClient(HttpClient httpClient, ILogger<IDMissionClient> logger, IConfiguration configuration)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+        _configuration = configuration;
+    }
+
+    public async Task<string> VerifyKycAsync(string documentImageBase64)
+    {
+        var url = _configuration["IDMission:Endpoint"] ?? throw new InvalidOperationException("Endpoint not configured");
+        var apiKey = _configuration["IDMission:ApiKey"] ?? throw new InvalidOperationException("ApiKey not configured");
+        var secret = _configuration["IDMission:Secret"] ?? throw new InvalidOperationException("Secret not configured");
+
+        var payload = new
+        {
+            image = documentImageBase64,
+            key = apiKey,
+            secret = secret
+        };
+
+        var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.PostAsync(url, content);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync();
+    }
+}

--- a/src/IDMissionDemo/appsettings.json
+++ b/src/IDMissionDemo/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "IDMission": {
+    "Endpoint": "https://demo.idmission.com/kyc",
+    "ApiKey": "YOUR_API_KEY",
+    "Secret": "YOUR_SECRET"
+  },
+  "AllowedHosts": "*"
+}

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,21 @@
+# IDMission Demo
+
+This directory contains a sample ASP.NET Core Web API project demonstrating how to integrate with the IDMission KYC verification service. The `KycController` exposes an endpoint at `/api/kyc` that accepts a base64 encoded image and forwards it to the configured IDMission endpoint.
+
+Configuration for the IDMission API endpoint, API key and secret can be set in `appsettings.json` or through environment variables.
+
+Due to limitations of this environment, the project was created manually without running `dotnet new` or restoring NuGet packages. To run the project locally you must have the .NET SDK installed.
+
+```bash
+# build and run
+cd src/IDMissionDemo
+ dotnet run
+```
+
+Then POST to `https://localhost:5001/api/kyc` with JSON body:
+
+```json
+{
+  "imageBase64": "<base64-encoded-image>"
+}
+```


### PR DESCRIPTION
## Summary
- create ASP.NET Core Web API sample demonstrating IDMission KYC integration
- wire up `KycController` and `IDMissionClient`
- add appsettings and README instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6853f705933c832cadec8c4181d5a78f